### PR TITLE
Fix inline link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The app is still in alpha; the database must be created manually.
 
 ## Supporting development
 
-If you find this bookmark manager useful, you can support development by joining the Nerd Club at [https://nerdclub.nots.co](nerdclub.nots.co).
+If you find this bookmark manager useful, you can support development by joining the Nerd Club at [nerdclub.nots.co](https://nerdclub.nots.co).
 
 ## License
 


### PR DESCRIPTION
I was scratching my head for two minutes why github is bugging on this link, why does it go to somewhere relative to the current path? The protocol is clearly specified. Is it the trailing slash that it wants to recognise it as a URL maybe? No, hmm.... Aha, the values are swapped! :D I've made that mistake before as well; not the most intuitive thing in Markdown indeed.

FTFY :D